### PR TITLE
Fix error in operator precedence

### DIFF
--- a/src/MAX30105.cpp
+++ b/src/MAX30105.cpp
@@ -162,7 +162,7 @@ boolean MAX30105::begin(TwoWire &wirePort, uint32_t i2cSpeed, uint8_t i2caddr) {
 
   // Step 1: Initial Communication and Verification
   // Check that a MAX30105 is connected
-  if (!readPartID() == MAX_30105_EXPECTEDPARTID) {
+  if (readPartID() != MAX_30105_EXPECTEDPARTID) {
     // Error -- Part ID read from MAX30105 does not match expected part ID.
     // This may mean there is a physical connectivity problem (broken wire, unpowered, etc).
     return false;


### PR DESCRIPTION
Hi, 
I had no opportunity to test with real hardware both scenarios but this seems an obvious fix.
I have a broken sensor only with caused this to happen.

Please double check it before merging.

Ilias