### PR TITLE
Sensor values mix up when using multiple sensors

### DIFF
--- a/src/MAX30105.cpp
+++ b/src/MAX30105.cpp
@@ -135,18 +135,6 @@ static const uint8_t SLOT_GREEN_PILOT = 		0x07;
 
 static const uint8_t MAX_30105_EXPECTEDPARTID = 0x15;
 
-//The MAX30105 stores up to 32 samples on the IC
-//This is additional local storage to the microcontroller
-const int STORAGE_SIZE = 4; //Each long is 4 bytes so limit this to fit on your micro
-struct Record
-{
-  uint32_t red[STORAGE_SIZE];
-  uint32_t IR[STORAGE_SIZE];
-  uint32_t green[STORAGE_SIZE];
-  byte head;
-  byte tail;
-} sense; //This is our circular buffer of readings from the sensor
-
 MAX30105::MAX30105() {
   // Constructor
 }

--- a/src/MAX30105.h
+++ b/src/MAX30105.h
@@ -140,4 +140,17 @@ class MAX30105 {
   void readRevisionID();
 
   void bitMask(uint8_t reg, uint8_t mask, uint8_t thing);
+ 
+   #define STORAGE_SIZE 4 //Each long is 4 bytes so limit this to fit on your micro
+  typedef struct Record
+  {
+    uint32_t red[STORAGE_SIZE];
+    uint32_t IR[STORAGE_SIZE];
+    uint32_t green[STORAGE_SIZE];
+    byte head;
+    byte tail;
+  } sense_struct; //This is our circular buffer of readings from the sensor
+
+  sense_struct sense;
+
 };


### PR DESCRIPTION
When using 2 (or more) sensors on the same device the sensor values read from the sensors can get mixed up.
The struct sense is defined as a global and is reused from multiple instances of the MAX30105 class.

Solution:
Declare sense as class private