### PR TITLE
Update example 8 Read SPO2

### DIFF
--- a/examples/Example8_SPO2/Example8_SPO2.ino
+++ b/examples/Example8_SPO2/Example8_SPO2.ino
@@ -49,8 +49,11 @@ int32_t spo2; //SPO2 value
 int8_t validSPO2; //indicator to show if the SPO2 calculation is valid
 int32_t heartRate; //heart rate value
 int8_t validHeartRate; //indicator to show if the heart rate calculation is valid
-
+#ifndef CONFIG_IDF_TARGET_ESP32  
 byte pulseLED = 11; //Must be on PWM pin
+#else
+byte pulseLED = 2; // Connected to the Onboard LED- Pin11 is strapping pin on ESP32
+#endif
 byte readLED = 13; //Blinks with each data read
 
 void setup()


### PR DESCRIPTION
🔧 Fix: Change Pulse LED Pin to Avoid ESP32 Reset Loop
Summary
Changed the default Pulse LED pin to avoid using ESP32 strapping pins (like GPIO11), which can cause boot/reset issues.

Why
New users often run into reset loops when using strapping pins. This fix helps prevent that and saves debugging time.

What Changed

Updated default Pulse LED pin to a safer GPIO.

Added a comment to explain the change.